### PR TITLE
Bowsprit statistics

### DIFF
--- a/.buzzy/links.yaml
+++ b/.buzzy/links.yaml
@@ -5,3 +5,6 @@
 - !git-env
   url: git://github.com/redjack/clogger.git
   commit: develop
+- !git-env
+  url: git://github.com/redjack/bowsprit.git
+  commit: develop

--- a/.buzzy/package.yaml
+++ b/.buzzy/package.yaml
@@ -5,4 +5,5 @@ build_dependencies:
 dependencies:
   - libcork >= 0.14.0
   - clogger >= 0.2.0
+  - bowsprit >= 2.0.0
 license: BSD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,10 @@ pkg_check_modules(CLOG REQUIRED clogger>=0.2.0)
 include_directories(${CLOG_INCLUDE_DIRS})
 link_directories(${CLOG_LIBRARY_DIRS})
 
+pkg_check_modules(BOWSPRIT REQUIRED bowsprit>=2.0.0)
+include_directories(${BOWSPRIT_INCLUDE_DIRS})
+link_directories(${BOWSPRIT_LIBRARY_DIRS})
+
 #-----------------------------------------------------------------------
 # Set some options
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------
-# Copyright © 2012-2014, RedJack, LLC.
+# Copyright © 2012-2015, RedJack, LLC.
 # All rights reserved.
 #
 # Please see the COPYING file in this distribution for license details.
@@ -50,6 +50,7 @@ set_target_properties(libvrt PROPERTIES
 target_link_libraries(libvrt
     ${CORK_LIBRARIES}
     ${CLOG_LIBRARIES}
+    ${BOWSPRIT_LIBRARIES}
 )
 
 install(TARGETS libvrt DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/varon-t.pc.in
+++ b/src/varon-t.pc.in
@@ -11,4 +11,4 @@ Version: @VERSION@
 URL: http://github.com/redjack/varon-t/
 Libs: -L${libdir} -lvrt
 Cflags: -I${includedir}
-Requires: libcork >= 0.14.0, clogger >= 0.2.0
+Requires: libcork >= 0.14.0, clogger >= 0.2.0, bowsprit >= 2.0.0

--- a/tests/test-perf-dq.c
+++ b/tests/test-perf-dq.c
@@ -1,10 +1,9 @@
 /* -*- coding: utf-8 -*-
  * ----------------------------------------------------------------------
- * Copyright © 2012, RedJack, LLC.
+ * Copyright © 2012-2015, RedJack, LLC.
  * All rights reserved.
  *
- * Please see the COPYING file in this distribution for license
- * details.
+ * Please see the COPYING file in this distribution for license details.
  * ----------------------------------------------------------------------
  */
 
@@ -62,8 +61,6 @@ unicast_test(uint32_t queue_size, uint64_t batch_size,
     run_func(q, clients, &elapsed);
     /*fprintf(stdout, "Result: %" PRId64 "\n", result);*/
     vrt_report_clock(elapsed, GENERATE_COUNT);
-    vrt_report_producer(p);
-    vrt_report_consumer(c);
     vrt_queue_free(q);
     return 0;
 }
@@ -127,10 +124,6 @@ sequencer_test(uint32_t queue_size, uint64_t batch_size,
     run_func(q, clients, &elapsed);
     /*fprintf(stdout, "Result: %" PRId64 "\n", result);*/
     vrt_report_clock(elapsed, GENERATE_COUNT);
-    vrt_report_producer(p1);
-    vrt_report_producer(p2);
-    vrt_report_producer(p3);
-    vrt_report_consumer(c);
     vrt_queue_free(q);
     return 0;
 }
@@ -183,10 +176,6 @@ multicast_test(uint32_t queue_size, uint64_t batch_size,
     run_func(q, clients, &elapsed);
     /*fprintf(stdout, "Result: %" PRId64 "\n", result);*/
     vrt_report_clock(elapsed, GENERATE_COUNT);
-    vrt_report_producer(p);
-    vrt_report_consumer(c1);
-    vrt_report_consumer(c2);
-    vrt_report_consumer(c3);
     vrt_queue_free(q);
     return 0;
 

--- a/tests/test-vrt.c
+++ b/tests/test-vrt.c
@@ -65,8 +65,6 @@ static int64_t  GENERATE_COUNT = DEFAULT_GENERATE_COUNT;
     fail_if_error(run_func(q, clients, &elapsed)); \
     fprintf(stdout, "Result: %" PRId64 "\n", result); \
     vrt_report_clock(elapsed, GENERATE_COUNT); \
-    vrt_report_producer(p); \
-    vrt_report_consumer(c); \
     vrt_queue_free(q);
 
 


### PR DESCRIPTION
Instead of a couple of simple counters inside the producer and consumer instances, we now use Bowsprit to manage quite a few statistics.