### PR TITLE
Updated the LMAX Disruptor site address

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://img.shields.io/travis/redjack/varon-t/develop.svg)](https://travis-ci.org/redjack/varon-t)
 
 The Varon-T library is a C implementation of the
-[disruptor queue](http://code.google.com/p/disruptor/), a high performance
+[disruptor queue](http://lmax-exchange.github.io/disruptor/), a high performance
 messaging library based on an efficient FIFO circular queue implementation.
 
 API documentation can be found [here](http://varon-t.readthedocs.org/).


### PR DESCRIPTION
Due to Google Code ending service, LMAX has moved its code/documentation over to Github @ http://lmax-exchange.github.io/disruptor/